### PR TITLE
Fix keyboard shortcuts interference with input fields

### DIFF
--- a/js/basim.js
+++ b/js/basim.js
@@ -495,6 +495,12 @@ function simParseCannonInput(eggs) {
 	return cannonCmds;
 }
 function simWindowOnKeyDown(e) { // food_drop
+	// Skip hotkey processing if user is typing in an input field
+	if (document.activeElement.tagName === "INPUT" || 
+		document.activeElement.tagName === "TEXTAREA") {
+		return;
+	}
+	
 	if (sim.IsRunning && pl.RepairCountdown === 0) {
 		if (e.key === "r") {
 			mAddItem(new fFood(pl.X, pl.Y, true, ++sim.CurrentFoodId));


### PR DESCRIPTION
When typing in input fields in the BaSim simulator, pressing certain keys (like "w", "r", "d", "f", or "g") would trigger game actions instead of typing the character. 

This PR adds a check to detect when a user is focused on an input field or textarea. When typing in these fields, keyboard shortcuts are disabled, allowing normal text input. This ensures keys only trigger simulator actions when not typing in an input field.
